### PR TITLE
Fixes authenticaton status due to API change

### DIFF
--- a/nessus/common.py
+++ b/nessus/common.py
@@ -28,7 +28,10 @@ class NessusConnection(object):
         f = urlopen(url, urlencode(params))
         dom = parse_xml(f)
         reply = dom.getElementsByTagName('reply')[0]
-        status = get_text_by_tag(reply, 'status')
+        status = None
+        for node in reply.childNodes:
+            if node.nodeName == 'status':
+                status = node.firstChild.nodeValue
         if status != 'OK':
             raise Exception("Authentication failure")
 


### PR DESCRIPTION
At some point the Nessus API changed its order and the 'status' node may not be the first node in a reply. The utils.get_text_by_tag would return the result of the first 'status' childNode, even if it was in a contents nodeName. This was causing a problem for /report/list that would put the status at the end:

```
In [46]: reply.childNodes
Out[46]:
[<DOM Element: contents at 0x10c8b2998>,
 <DOM Text node "u'\n'">,
 <DOM Element: status at 0x10c911050>,
 <DOM Text node "u'\n'">]
```

This change runs through the reply node searching for a status nodeName and then extracting the status result. Original patch from @skabople in https://github.com/KvasirSecurity/Kvasir/issues/90
